### PR TITLE
Optimize ScaleFactorCallback 

### DIFF
--- a/lib/scaled_app.dart
+++ b/lib/scaled_app.dart
@@ -45,7 +45,7 @@ class ScaledWidgetsFlutterBinding extends WidgetsFlutterBinding {
   double get scale =>
       scaleFactor(window.physicalSize / window.devicePixelRatio);
 
-  double get devicePixelRatioScaled => window.devicePixelRatio * scale;
+  double devicePixelRatioScaled = 0;
 
   bool get isScaling => scale != 1.0;
 
@@ -71,6 +71,7 @@ class ScaledWidgetsFlutterBinding extends WidgetsFlutterBinding {
     if (window.physicalSize.isEmpty) {
       return super.createViewConfiguration();
     } else {
+      devicePixelRatioScaled = window.devicePixelRatio * scale;
       return ViewConfiguration(
         size: window.physicalSize / devicePixelRatioScaled,
         devicePixelRatio: devicePixelRatioScaled,


### PR DESCRIPTION
When i used this library the ScaleFactorCallback was not only called on every screen update, but also on every pointer update.
I don't know if this is the intended behaviour but on web this triggers the function over 300 times on a mouse movement.

This fix only calls ScaleFactorCallback when the screen changes.