### PR TITLE
Fix: memory leak when devicePixelRatioScaled is zero

### DIFF
--- a/lib/scaled_app.dart
+++ b/lib/scaled_app.dart
@@ -50,6 +50,14 @@ class ScaledWidgetsFlutterBinding extends WidgetsFlutterBinding {
     return scaleFactor(physicalSize / devicePixelRatio);
   }
 
+  double get _safeDevicePixelRatio {
+    if (devicePixelRatioScaled == 0) {
+      final view = platformDispatcher.implicitView;
+      return view?.devicePixelRatio ?? 1.0;
+    }
+    return devicePixelRatioScaled;
+  }
+
   double devicePixelRatioScaled = 0;
 
   bool get isScaling => scale != 1.0;
@@ -121,9 +129,7 @@ class ScaledWidgetsFlutterBinding extends WidgetsFlutterBinding {
     try {
       _pendingPointerEvents.addAll(PointerEventConverter.expand(
         packet.data,
-        (viewId) {
-          return devicePixelRatioScaled;
-        },
+        (viewId) => _safeDevicePixelRatio,
       ));
       if (!locked) {
         _flushPointerEventQueue();


### PR DESCRIPTION
## Fix: render tree memory leak caused by `devicePixelRatioScaled = 0` at initialization

### Problem

`ScaledWidgetsFlutterBinding` initializes `devicePixelRatioScaled` to `0`:

```dart
double devicePixelRatioScaled = 0;
```

This value is only updated inside `createViewConfigurationFor`, which runs during
the first layout frame. Any pointer event that arrives **before** the first frame
(e.g. a tap during startup, or a fast tap right after navigation) is processed with
ratio `0`:

```dart
_pendingPointerEvents.addAll(PointerEventConverter.expand(
  packet.data,
  (viewId) => devicePixelRatioScaled,  // ← 0 here
));
```

`PointerEventConverter.expand` with ratio `0` produces pointer events with
invalid/infinite coordinates. When `GestureBinding.handlePointerEvent` processes
the resulting `PointerDownEvent`, it:

1. Runs a hit test against the current render tree
2. Stores the `BoxHitTestResult` in `GestureBinding._hitTests[pointer]`
3. Waits for the matching `PointerUpEvent` to clean up

Because the `PointerDownEvent` was malformed (coordinates derived from ratio `0`),
the matching `PointerUpEvent` (converted with the correct ratio) is treated as a
**different pointer**. The entry in `_hitTests` is never removed.

### Consequence: permanent render tree leak

Each orphaned `BoxHitTestResult` holds a list of `BoxHitTestEntry` objects. Each
entry holds a direct reference to a `RenderBox` in the page's render tree. Because
`_hitTests` is a strong-reference map anchored to the `GestureBinding` (and
therefore to the `Isolate`), the **entire render tree of the affected page can
never be garbage collected**, even after the page is popped from the navigator.

Observed in Flutter DevTools (profile mode, heap snapshot diff after navigation):

| Class | New | Released | Delta | Retained |
|---|---|---|---|---|
| `BoxHitTestResult` | 2 | 0 | +2 | **269.1 KB** |
| `BoxHitTestEntry` | 78 | 0 | +78 | 265.6 KB |
| `RenderFlex` | 15 | 0 | +15 | 167.9 KB |
| `RenderConstrainedBox` | 27 | 1 | +26 | 140.9 KB |
| `FlexParentData` | 37 | 0 | +37 | 111.1 KB |

The shortest retaining path for `BoxHitTestResult` goes directly through
`ScaledWidgetsFlutterBinding`, confirming the binding as the retention root.

In long-running applications (kiosk, POS terminals) that never restart, this leak
accumulates with every navigation, growing proportionally to the size of each
discarded page's render tree.

### Fix

Add a safe fallback getter that returns the real device pixel ratio when
`devicePixelRatioScaled` has not yet been initialized:

```dart
double get _safeDevicePixelRatio {
  if (devicePixelRatioScaled == 0) {
    final view = platformDispatcher.implicitView;
    return view?.devicePixelRatio ?? 1.0;
  }
  return devicePixelRatioScaled;
}
```

Use it in `_handlePointerDataPacket`:

```dart
_pendingPointerEvents.addAll(PointerEventConverter.expand(
  packet.data,
  (viewId) => _safeDevicePixelRatio,  // ← safe fallback
));
```

This ensures that pointer events are always converted with a valid, non-zero ratio,
keeping `PointerDown`/`PointerUp` pointer IDs consistent so `GestureBinding._hitTests`
is properly cleaned up after every gesture.

### Affected versions

Confirmed on `scaled_app 2.3.0`. The root cause (`devicePixelRatioScaled = 0`
initial value with no guard before use) has been present since the custom pointer
handling was introduced.